### PR TITLE
Add TeamMembershipChecker interface

### DIFF
--- a/src/main/java/com/briancabrera/teamtasks/domain/service/TeamMembershipChecker.java
+++ b/src/main/java/com/briancabrera/teamtasks/domain/service/TeamMembershipChecker.java
@@ -1,5 +1,21 @@
 package com.briancabrera.teamtasks.domain.service;
 
-public class TeamMembershipChecker {
-    
+import java.util.UUID;
+
+/**
+ * Abstraction used to verify if a user belongs to a team.
+ * This interface will be implemented by infrastructure layers
+ * so use cases can validate team membership without depending
+ * on specific implementations.
+ */
+public interface TeamMembershipChecker {
+
+    /**
+     * Checks whether a user is a member of a given team.
+     *
+     * @param userId identifier of the user to check
+     * @param teamId identifier of the team
+     * @return {@code true} if the user belongs to the team, otherwise {@code false}
+     */
+    boolean isUserMemberOfTeam(UUID userId, UUID teamId);
 }


### PR DESCRIPTION
## Summary
- define the `TeamMembershipChecker` interface in `domain.service`

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6873f692e9ac832cb5338afe5df15927