### PR TITLE
Add TaskRepository interface

### DIFF
--- a/src/main/java/com/briancabrera/teamtasks/domain/repository/TaskRepository.java
+++ b/src/main/java/com/briancabrera/teamtasks/domain/repository/TaskRepository.java
@@ -1,5 +1,27 @@
 package com.briancabrera.teamtasks.domain.repository;
 
-public class TaskRepository {
-    
+import com.briancabrera.teamtasks.domain.model.Task;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Abstraction of the persistence layer for {@link Task} entities.
+ */
+public interface TaskRepository {
+
+    /**
+     * Persist a task instance.
+     *
+     * @param task the task to save
+     */
+    void save(Task task);
+
+    /**
+     * Retrieve all active tasks assigned to a specific user.
+     *
+     * @param userId the id of the user
+     * @return list of active tasks
+     */
+    List<Task> findActiveTasksByUser(UUID userId);
 }


### PR DESCRIPTION
## Summary
- implement `TaskRepository` interface in domain layer

## Testing
- `mvn -q test` *(fails: plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6873f67d6f74832c801b3b6a5780cfcb