### PR TITLE
Add CreateTask use case and DTOs

### DIFF
--- a/src/main/java/com/briancabrera/teamtasks/application/dto/CreateTaskCommand.java
+++ b/src/main/java/com/briancabrera/teamtasks/application/dto/CreateTaskCommand.java
@@ -1,5 +1,23 @@
 package com.briancabrera.teamtasks.application.dto;
 
-public class CreateTaskCommand {
-    
+import com.briancabrera.teamtasks.domain.model.Task;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Command object used to request the creation of a new {@link Task}.
+ * Bean Validation annotations enforce basic constraints on the input data.
+ */
+public record CreateTaskCommand(
+        @NotBlank String title,
+        @NotBlank String description,
+        @NotNull @Future LocalDate dueDate,
+        @NotNull Task.Priority priority,
+        @NotNull UUID assignedUserId,
+        @NotNull UUID teamId
+) {
 }

--- a/src/main/java/com/briancabrera/teamtasks/application/dto/TaskResponseDTO.java
+++ b/src/main/java/com/briancabrera/teamtasks/application/dto/TaskResponseDTO.java
@@ -1,5 +1,24 @@
 package com.briancabrera.teamtasks.application.dto;
 
-public enum TaskResponseDTO {
-    
+import com.briancabrera.teamtasks.domain.model.Task;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Data transfer object representing a task returned by the application layer.
+ */
+public record TaskResponseDTO(
+        UUID id,
+        String title,
+        String description,
+        LocalDate dueDate,
+        Task.Priority priority,
+        Task.Status status,
+        UUID assignedUserId,
+        UUID teamId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
 }

--- a/src/main/java/com/briancabrera/teamtasks/application/usecases/CreateTaskUseCase.java
+++ b/src/main/java/com/briancabrera/teamtasks/application/usecases/CreateTaskUseCase.java
@@ -1,5 +1,77 @@
 package com.briancabrera.teamtasks.application.usecases;
 
+import com.briancabrera.teamtasks.application.dto.CreateTaskCommand;
+import com.briancabrera.teamtasks.application.dto.TaskResponseDTO;
+import com.briancabrera.teamtasks.domain.model.Task;
+import com.briancabrera.teamtasks.domain.repository.TaskRepository;
+import com.briancabrera.teamtasks.domain.service.TeamMembershipChecker;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Application service that handles the creation of tasks.
+ */
 public class CreateTaskUseCase {
-    
+
+    private final TaskRepository taskRepository;
+    private final TeamMembershipChecker teamMembershipChecker;
+
+    public CreateTaskUseCase(TaskRepository taskRepository,
+                             TeamMembershipChecker teamMembershipChecker) {
+        this.taskRepository = taskRepository;
+        this.teamMembershipChecker = teamMembershipChecker;
+    }
+
+    /**
+     * Creates a new task based on the provided command.
+     *
+     * @param command data required to create the task
+     * @return representation of the created task
+     */
+    public TaskResponseDTO execute(@Valid CreateTaskCommand command) {
+        UUID userId = command.assignedUserId();
+        UUID teamId = command.teamId();
+
+        if (!teamMembershipChecker.isUserMemberOfTeam(userId, teamId)) {
+            throw new IllegalArgumentException("User is not a member of the team");
+        }
+
+        List<Task> activeTasks = taskRepository.findActiveTasksByUser(userId);
+        if (activeTasks.size() >= 5) {
+            throw new IllegalStateException("User already has 5 active tasks");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        Task task = new Task(
+                UUID.randomUUID(),
+                command.title(),
+                command.description(),
+                command.dueDate(),
+                command.priority(),
+                Task.Status.PENDING,
+                userId,
+                teamId,
+                now,
+                now
+        );
+
+        taskRepository.save(task);
+
+        return new TaskResponseDTO(
+                task.getId(),
+                task.getTitle(),
+                task.getDescription(),
+                task.getDueDate(),
+                task.getPriority(),
+                task.getStatus(),
+                task.getAssignedUserId(),
+                task.getTeamId(),
+                task.getCreatedAt(),
+                task.getUpdatedAt()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- implement `CreateTaskCommand` with validation
- implement `TaskResponseDTO` to expose task data
- implement `CreateTaskUseCase` logic

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f8604f24832c9043f2441bfd6c54