### PR TITLE
Implement team task listing

### DIFF
--- a/src/main/java/com/briancabrera/teamtasks/application/dto/ListTasksByTeamQuery.java
+++ b/src/main/java/com/briancabrera/teamtasks/application/dto/ListTasksByTeamQuery.java
@@ -1,5 +1,17 @@
 package com.briancabrera.teamtasks.application.dto;
 
-public class ListTasksByTeamQuery {
-    
+import com.briancabrera.teamtasks.domain.model.Task;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Query object used to request tasks belonging to a team
+ * optionally filtered by status and priority.
+ */
+public record ListTasksByTeamQuery(
+        UUID teamId,
+        Optional<Task.Status> status,
+        Optional<Task.Priority> priority
+) {
 }

--- a/src/main/java/com/briancabrera/teamtasks/application/usecases/ListTasksByTeamUseCase.java
+++ b/src/main/java/com/briancabrera/teamtasks/application/usecases/ListTasksByTeamUseCase.java
@@ -1,5 +1,53 @@
 package com.briancabrera.teamtasks.application.usecases;
 
+import com.briancabrera.teamtasks.application.dto.ListTasksByTeamQuery;
+import com.briancabrera.teamtasks.application.dto.TaskResponseDTO;
+import com.briancabrera.teamtasks.domain.model.Task;
+import com.briancabrera.teamtasks.domain.repository.TaskRepository;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Application service that retrieves tasks for a team applying optional filters.
+ */
+@Service
 public class ListTasksByTeamUseCase {
-    
+
+    private final TaskRepository taskRepository;
+
+    public ListTasksByTeamUseCase(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    /**
+     * Returns tasks for a team applying optional status and priority filters.
+     *
+     * @param query the query containing team id and filters
+     * @return list of tasks mapped to DTOs
+     */
+    public List<TaskResponseDTO> execute(ListTasksByTeamQuery query) {
+        List<Task> tasks = taskRepository.findByTeamWithFilters(
+                query.teamId(),
+                query.status(),
+                query.priority()
+        );
+
+        return tasks.stream()
+                .map(task -> new TaskResponseDTO(
+                        task.getId(),
+                        task.getTitle(),
+                        task.getDescription(),
+                        task.getDueDate(),
+                        task.getPriority(),
+                        task.getStatus(),
+                        task.getAssignedUserId(),
+                        task.getTeamId(),
+                        task.getCreatedAt(),
+                        task.getUpdatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/briancabrera/teamtasks/domain/repository/TaskRepository.java
+++ b/src/main/java/com/briancabrera/teamtasks/domain/repository/TaskRepository.java
@@ -2,6 +2,8 @@ package com.briancabrera.teamtasks.domain.repository;
 
 import com.briancabrera.teamtasks.domain.model.Task;
 
+import java.util.Optional;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -24,4 +26,16 @@ public interface TaskRepository {
      * @return list of active tasks
      */
     List<Task> findActiveTasksByUser(UUID userId);
+
+    /**
+     * Retrieve tasks for a team optionally filtered by status and priority.
+     *
+     * @param teamId   the team identifier
+     * @param status   optional status filter
+     * @param priority optional priority filter
+     * @return list of tasks matching the filters
+     */
+    List<Task> findByTeamWithFilters(UUID teamId,
+                                     Optional<Task.Status> status,
+                                     Optional<Task.Priority> priority);
 }

--- a/src/main/java/com/briancabrera/teamtasks/infrastructure/persistence/JpaTaskRepositoryAdapter.java
+++ b/src/main/java/com/briancabrera/teamtasks/infrastructure/persistence/JpaTaskRepositoryAdapter.java
@@ -4,6 +4,8 @@ import com.briancabrera.teamtasks.domain.model.Task;
 import com.briancabrera.teamtasks.domain.repository.TaskRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -30,6 +32,25 @@ public class JpaTaskRepositoryAdapter implements TaskRepository {
     @Override
     public List<Task> findActiveTasksByUser(UUID userId) {
         List<TaskEntity> entities = repository.findByAssignedUserIdAndStatusNot(userId, Task.Status.DONE);
+        return entities.stream()
+                .map(TaskMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Task> findByTeamWithFilters(UUID teamId,
+                                            Optional<Task.Status> status,
+                                            Optional<Task.Priority> priority) {
+        List<TaskEntity> entities;
+        if (status.isPresent() && priority.isPresent()) {
+            entities = repository.findByTeamIdAndStatusAndPriority(teamId, status.get(), priority.get());
+        } else if (status.isPresent()) {
+            entities = repository.findByTeamIdAndStatus(teamId, status.get());
+        } else if (priority.isPresent()) {
+            entities = repository.findByTeamIdAndPriority(teamId, priority.get());
+        } else {
+            entities = repository.findByTeamId(teamId);
+        }
         return entities.stream()
                 .map(TaskMapper::toDomain)
                 .collect(Collectors.toList());

--- a/src/main/java/com/briancabrera/teamtasks/infrastructure/persistence/SpringDataTaskRepository.java
+++ b/src/main/java/com/briancabrera/teamtasks/infrastructure/persistence/SpringDataTaskRepository.java
@@ -20,4 +20,14 @@ public interface SpringDataTaskRepository extends JpaRepository<TaskEntity, UUID
      * @return matching task entities
      */
     List<TaskEntity> findByAssignedUserIdAndStatusNot(UUID userId, Task.Status status);
+
+    List<TaskEntity> findByTeamId(UUID teamId);
+
+    List<TaskEntity> findByTeamIdAndStatus(UUID teamId, Task.Status status);
+
+    List<TaskEntity> findByTeamIdAndPriority(UUID teamId, Task.Priority priority);
+
+    List<TaskEntity> findByTeamIdAndStatusAndPriority(UUID teamId,
+                                                      Task.Status status,
+                                                      Task.Priority priority);
 }

--- a/src/test/java/com/briancabrera/teamtasks/entrypoints/rest/TaskControllerTest.java
+++ b/src/test/java/com/briancabrera/teamtasks/entrypoints/rest/TaskControllerTest.java
@@ -2,6 +2,7 @@ package com.briancabrera.teamtasks.entrypoints.rest;
 
 import com.briancabrera.teamtasks.application.dto.CreateTaskCommand;
 import com.briancabrera.teamtasks.application.dto.TaskResponseDTO;
+import com.briancabrera.teamtasks.application.usecases.ListTasksByTeamUseCase;
 import com.briancabrera.teamtasks.application.usecases.CreateTaskUseCase;
 import com.briancabrera.teamtasks.domain.model.Task;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,10 +16,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,6 +33,9 @@ class TaskControllerTest {
 
     @MockBean
     private CreateTaskUseCase createTaskUseCase;
+
+    @MockBean
+    private ListTasksByTeamUseCase listTasksByTeamUseCase;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -69,5 +75,32 @@ class TaskControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json("{\"id\":\"" + taskId + "\"}", false));
+    }
+
+    @Test
+    void listByTeam_shouldReturn200_withTasks() throws Exception {
+        UUID taskId = UUID.randomUUID();
+        UUID teamId = UUID.randomUUID();
+        TaskResponseDTO dto = new TaskResponseDTO(
+                taskId,
+                "Title",
+                "Desc",
+                LocalDate.now().plusDays(1),
+                Task.Priority.HIGH,
+                Task.Status.PENDING,
+                UUID.randomUUID(),
+                teamId,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+
+        when(listTasksByTeamUseCase.execute(any())).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/tasks/team/" + teamId)
+                        .param("status", Task.Status.PENDING.name())
+                        .param("priority", Task.Priority.HIGH.name()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("[{'id':'" + taskId + "'}]", false));
     }
 }


### PR DESCRIPTION
## Summary
- add `ListTasksByTeamQuery` DTO
- implement `ListTasksByTeamUseCase`
- extend `TaskRepository` with a new method and provide JPA implementation
- add Spring Data queries for team-based retrieval
- expose new `/tasks/team/{teamId}` endpoint
- cover new endpoint with controller test

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugin due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68741350bcb4832cad4f0f7afbff9d1a